### PR TITLE
This fixes the entrypoint in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "graphscape",
   "version": "0.0.1",
   "description": "Measure cognitive distances among visualizations.",
-  "main": "lp.js",
+  "main": "src/graphscape.js",
   "scripts": {
     "test": "mocha --recursive",
     "build" : "browserify src/graphscape.js -o graphscape.js -s graphscape",


### PR DESCRIPTION
This patch fixes the entrypoint in the package.json to allow an easy installation via yarn or npm.

For Example with `yarn add https://github.com/uwdata/graphscape`

This PR mitigates #17, however properly tagged builds and published releases to npm would still be nice to have.